### PR TITLE
add index.d.ts to package.json > files

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "tape": "^3.5.0"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "homepage": "https://github.com/koopjs/esri-extent",
   "keywords": [


### PR DESCRIPTION
Without this, index.d.ts isn't included when you `npm install esri-extent` :)

cc @jgravois 